### PR TITLE
Fix link in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ builds:
 
 ## Documentation
 
-📚 **[Read the full documentation →](https://github.io/kaeawc/android-mcp-sdk/)**
+📚 **[Read the full documentation →](https://kaeawc.github.io/android-mcp-sdk/)**
 
-- [Getting Started Guide](docs/getting-started.md)
-- [Usage Examples](docs/usage.md)
-- [API Reference](docs/api-reference.md)
-- [Transport Configuration](docs/transport.md)
+- [Getting Started Guide](https://kaeawc.github.io/android-mcp-sdk/getting-started/)
+- [Usage Examples](https://kaeawc.github.io/android-mcp-sdk/usage/)
+- [Transport Configuration](https://kaeawc.github.io/android-mcp-sdk/transport/)
+- [API Reference](https://kaeawc.github.io/android-mcp-sdk/api-reference/)
 - [Development Roadmap](roadmap/README.md)
 
 ## License


### PR DESCRIPTION
This also adjusts the other links to go to the github pages and adjusts the order to be the same as in the nav bar on github pages.